### PR TITLE
specify category, so plugin appears in factory

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -1,5 +1,5 @@
 {
   "name": "Datscript",
   "title": "Datscript Plugin",
-  "category": "data|format|other"
+  "category": "data"
 }


### PR DESCRIPTION
Specify category in factory.json, so that plugin is available in the factory.
