### PR TITLE
fix npm's link to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/fedwiki/wiki-plugin-datscript.git"
+    "url": "https://github.com/maxogden/wiki-plugin-datscript.git"
   },
   "bugs": {
-    "url": "https://github.com/fedwiki/wiki-plugin-datscript/issues"
+    "url": "https://github.com/maxogden/wiki-plugin-datscript/issues"
   },
   "engines": {
     "node": "0.10"


### PR DESCRIPTION
Npm has the wrong link to this repo. This should fix that. I'll leave it to Max to bump the version number (is this required?) and publish an update.
